### PR TITLE
Fix closure compiler build failure, update gnuplot, add license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Eumeryx
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/apply_template.sh
+++ b/apply_template.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 template="$(readlink -f "$0" | xargs dirname)/template/gnuplot.js"
 
@@ -6,4 +6,4 @@ mv "$1" "${1}.blk"
 
 grep //{{output.js}} -B 999 "$template" > "$1"
 sed 's/document.currentScript/currentScript/g' "${1}.blk" >> "$1"
-grep //{{output.js}} -A 999 "$template" >> "$1" 
+grep //{{output.js}} -A 999 "$template" >> "$1"

--- a/build.sh
+++ b/build.sh
@@ -85,7 +85,7 @@ function build {
   emmake make \
     CFLAGS="-Oz -flto" \
     CXXFLAGS="-Oz -flto" \
-    LDFLAGS="--js-transform $ROOT/apply_template.sh -sINVOKE_RUN=0 -sENVIRONMENT=web -sINCOMING_MODULE_JS_API=printErr,onAbort,onRuntimeInitialized,instantiateWasm" \
+    LDFLAGS="--js-transform $ROOT/apply_template.sh -sINVOKE_RUN=0 -sENVIRONMENT=web -sINCOMING_MODULE_JS_API=arguments,printErr,onAbort,onRuntimeInitialized,instantiateWasm" \
     EXEEXT=".js" \
     gnuplot
 }

--- a/build.sh
+++ b/build.sh
@@ -85,7 +85,7 @@ function build {
   emmake make \
     CFLAGS="-Oz -flto" \
     CXXFLAGS="-Oz -flto" \
-    LDFLAGS="--js-transform $ROOT/apply_template.sh --closure 1 -sINVOKE_RUN=0 -sENVIRONMENT=web -sINCOMING_MODULE_JS_API=printErr,onAbort,onRuntimeInitialized,instantiateWasm" \
+    LDFLAGS="--js-transform $ROOT/apply_template.sh -sINVOKE_RUN=0 -sENVIRONMENT=web -sINCOMING_MODULE_JS_API=printErr,onAbort,onRuntimeInitialized,instantiateWasm" \
     EXEEXT=".js" \
     gnuplot
 }

--- a/changelog.md
+++ b/changelog.md
@@ -3,3 +3,9 @@
 ## v0.0.1
 
 - Initial release.
+
+## v0.0.2
+
+- Fix issue where closure compiler fails
+- Add license file
+- Update to gnuplot 5.4.10

--- a/gnuplot_version
+++ b/gnuplot_version
@@ -1,3 +1,3 @@
-/gnuplot/5.4.3/gnuplot-5.4.3.tar.gz
-9bb03cfa77e38924e08ffbb9eb59d8b1
-5656008
+/gnuplot/5.4.10/gnuplot-5.4.10.tar.gz
+334851e63450362bdb95e67fa8a23665
+5687565

--- a/test/node.js
+++ b/test/node.js
@@ -38,7 +38,9 @@ createGnuplot((importObject, callback) => {
       exitCode++;
     }
   }
-}).catch(() => {
+}).catch((e) => {
   console.error('...Failed\n');
+  console.error(e.message);
+  console.error(e.stack);
   exitCode++;
 }).finally(() => exit(exitCode));


### PR DESCRIPTION
Hello, I've made the following updates:
- Fix closure compiler build failure (removed `--closure 1` from LDFLAGS)
- Fix to an issue with the latest version of emscripten (add `arguments` to `INCOMING_MODULE_JS_API`)
- Update to latest gnuplot version (5.4.10)
- Add license file (MIT License)
- Update changelog
- Switch `apply_template.sh` to use `/bin/bash` for consistency (Note: macos symlinks `/bin/sh` to `/bin/bash`, which can cause behavior discrepancies in shell scripts that use `/bin/sh` between macos and linux)

Notes:
- Test passes, running plots in the browser from the `dist` folder works
- Do you want to add the MIT license? I think that's the simplest OSS license to use. Let me know if you want to use something else, I'd be glad to change it.